### PR TITLE
Replicate session failure with single test

### DIFF
--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -4,7 +4,7 @@ module.exports = {
     const reqType = req.isSocket ? 'socket' : 'http';
     console.log(`\nSetting session: from ${reqType}`);
     console.log(req.signedCookies);
-    console.log(req.session); // undefined when requesting with socket client
+    console.log(req.session);
     req.session.hasSession = true;
     if (req.body.customVal) {
       req.session.customVal = req.body.customVal;

--- a/cypress/e2e/reproduction.cy.js
+++ b/cypress/e2e/reproduction.cy.js
@@ -4,6 +4,13 @@ describe('Replication test - Fundamentals', () => {
     // cy.visit('/');
   });
 
+  // THIS WORKS WHEN IT ISN'T THE ONLY TEST
+  it.only('Sets session data using socket after visiting the page', () => {
+    cy.visit('/');
+    cy.setSessionViaSocket();
+    cy.getSessionViaSocket();
+  });
+
   it('Sets session data using http', () => {
     cy.setSessionViaHttp();
     cy.getSessionViaHttp();


### PR DESCRIPTION
It looks to be the case that if we only run one test and it visits the page before setting the socket session data, that this breaks the session such that it doesn't correctly persist for the second request